### PR TITLE
fix PDU1 example and add PDU2

### DIFF
--- a/can-j1939-kickstart.md
+++ b/can-j1939-kickstart.md
@@ -99,7 +99,11 @@ produces **1BFFFF90#0123456789ABCDEF** ,
 
 ### Use PDU1 PGN
 
-	./testj1939 -s can0:0x80,0x12345
+	./testj1939 -s can0:0x80,0x12300
+	
+### Use PDU2 PGN
+
+	./testj1939 -s can0:0x80,0x1f301
 
 emits **1923FF80#0123456789ABCDEF** .
 


### PR DESCRIPTION
With PDU1 format < 240 (peer-to-peer), PDU specific contains the target address. Global (255) can also be
used as target address. Then the parameter group is aimed at all devices. In this case, the PGN is formed
only from PDU format.
With PDU2 format >= 240 (broadcast), PDU format together with the Group Extension in the PDU specific
field forms the PGN of the transmitted parameter group.